### PR TITLE
Updated dev.in file to add 'wincertstore' line 

### DIFF
--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -25,3 +25,4 @@ pytest-cov==3.0.0
 pytorch-lightning==1.6.3
 torchmetrics<0.8
 wandb==0.12.17
+wincertstore


### PR DESCRIPTION
Fix for Windows 11 error when running 'conda pip-tools'